### PR TITLE
Adds Crossplane to the cluster

### DIFF
--- a/base/crossplane-system/helm-release.yaml
+++ b/base/crossplane-system/helm-release.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: crossplane
+  namespace: crossplane-system
+spec:
+  chart:
+    spec:
+      chart: crossplane
+      reconcileStrategy: ChartVersion
+      sourceRef:
+        kind: HelmRepository
+        name: crossplane
+      version: 1.10.1
+  interval: 1m0s
+

--- a/base/crossplane-system/helm-repository.yaml
+++ b/base/crossplane-system/helm-repository.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: crossplane
+  namespace: crossplane-system
+spec:
+  interval: 1m0s
+  url: https://charts.crossplane.io/stable
+

--- a/base/crossplane-system/namespace.yaml
+++ b/base/crossplane-system/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  creationTimestamp: null
+  name: crossplane
+spec: {}
+status: {}


### PR DESCRIPTION
TL;DR
-----

Couples Crossplane with Cluster API for a powerful management cluster

Details
-------

Installs Crossplane. I've been wanting to experiment with incorporating
Crossplan into the lab for a while, and decided that the shift to using
GitOps was a good time to do it.
